### PR TITLE
v.0.3.2

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -48,11 +48,11 @@ class Program
     static void CheckPaths(string[] args)
     {
         if (args.Length < 2 || !Directory.Exists(args[0]) && !Directory.Exists(args[1]))
-            ExitWithError("You must specify a valid .NET project AND destination folder.", 1);
+            ExitWithError("You must specify a valid .NET project AND destination folder.\n", 1);
         if (Directory.Exists(args[0]) && !Directory.Exists(args[1]))
-            ExitWithError($"{args[1]} is not a valid folder", 2);
+            ExitWithError($"{args[1]} is not a valid folder\n", 2);
         if (!Directory.Exists(args[0]) && Directory.Exists(args[1]))
-            ExitWithError($"{args[0]} is not a valid folder", 3);
+            ExitWithError($"{args[0]} is not a valid folder\n", 3);
         
         projectDir = ConsolidatePath(args[0]);
         destination = ConsolidatePath(args[1]);
@@ -101,9 +101,9 @@ class Program
         var absolutePath = location[0];
 
         if (location.Length < 1)
-            ExitWithError($"No .csproj found in {project}", 10);
+            ExitWithError($"No .csproj found in {project}\n", 10);
         if (location.Length > 1)
-            ExitWithError($"More than one .csproj found in {project}", 11);
+            ExitWithError($"More than one .csproj found in {project}\n", 11);
         
         var folderSplit = absolutePath.Split('/');
         var folder = string.Join('/', folderSplit.Take(folderSplit.Length - 1));

--- a/Program.cs
+++ b/Program.cs
@@ -54,8 +54,8 @@ class Program
         if (!Directory.Exists(args[0]) && Directory.Exists(args[1]))
             ExitWithError($"{args[0]} is not a valid folder\n", 3);
         
-        projectDir = ConsolidatePath(args[0]);
-        destination = ConsolidatePath(args[1]);
+        projectDir = GetRelativePath(args[0]);
+        destination = GetRelativePath(args[1]);
     }
 
     static void ParseArgs(string[] args)
@@ -100,9 +100,9 @@ class Program
         var location = bash.Output.Split("\n", StringSplitOptions.RemoveEmptyEntries);
 
         if (location.Length < 1)
-            ExitWithError($"No .csproj found in {project}\n", 10);
+            ExitWithError($"No .csproj found in {GetRelativePath(project)}\n", 10);
         if (location.Length > 1)
-            ExitWithError($"More than one .csproj found in {project}\n", 11);
+            ExitWithError($"More than one .csproj found in {GetRelativePath(project)}\n", 11);
         
         var absolutePath = location[0];
         var folderSplit = absolutePath.Split('/');
@@ -211,13 +211,6 @@ class Program
     static void SayFinished(string message)
     {
         Printer.WriteLine($"{Clr.Green}{message}{Clr.Default}");
-    }
-
-    static string ConsolidatePath(string path)
-    {
-        bash.Command($"cd {path} && dirs -0", redirect: true);
-        var output = bash.Output.Split("\n", StringSplitOptions.RemoveEmptyEntries);
-        return output[0];
     }
 
     static void SayHello()

--- a/Program.cs
+++ b/Program.cs
@@ -292,9 +292,15 @@ class Program
 
     static void ExitWithError(string message, int code)
     {
-        Printer.Write($"{Clr.Red}{message}{Clr.Default}");
-        if (Verbose) WriteToErrorLog("[Error message was written to verbose output]", code);
-        else WriteToErrorLog(message, code);
+        if (Verbose)
+        {
+            WriteToErrorLog("[Error message was written to verbose output]", code);
+        }
+        else
+        {
+            Printer.Write($"{Clr.Red}{message}{Clr.Default}");
+            WriteToErrorLog(message, code);
+        }
         SayBye();
         Environment.Exit(code);
     }

--- a/Program.cs
+++ b/Program.cs
@@ -98,13 +98,13 @@ class Program
         
         bash.Command($"find {project} -maxdepth 1 -name '*.csproj'", redirect: true);
         var location = bash.Output.Split("\n", StringSplitOptions.RemoveEmptyEntries);
-        var absolutePath = location[0];
 
         if (location.Length < 1)
             ExitWithError($"No .csproj found in {project}\n", 10);
         if (location.Length > 1)
             ExitWithError($"More than one .csproj found in {project}\n", 11);
         
+        var absolutePath = location[0];
         var folderSplit = absolutePath.Split('/');
         var folder = string.Join('/', folderSplit.Take(folderSplit.Length - 1));
         csproj = folderSplit[folderSplit.Length - 1];

--- a/Program.cs
+++ b/Program.cs
@@ -67,6 +67,9 @@ class Program
 
         if (args == null || args.Length == 0)
             HelpMenu();
+        
+        if (args[0] == "--clear-log")
+            ClearLogs();
 
         for (int i = 0; i < args.Length; i++)
         {
@@ -264,6 +267,15 @@ class Program
             + $"    https://github.com/phil-harmoniq/netpkg-tool\n"
             + $"    Copyright (c) 2017 - MIT License\n"
         );
+        SayBye();
+        Environment.Exit(0);
+    }
+
+    static void ClearLogs()
+    {
+        Console.Write($"Clear log at {GetRelativePath(configDir)}/error.log");
+        bash.Command($"rm -f {configDir}/error.log");
+        CheckCommandOutput(errorCode: 5);
         SayBye();
         Environment.Exit(0);
     }

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 A pre-packaged version of the most current netpkg-tool is available from the [releases tab](https://github.com/phil-harmoniq/netpkg-tool/releases):
 
 ```bash
-# The Master branch will always hold the latest release
-wget https://github.com/phil-harmoniq/netpkg-tool/releases/download/master/netpkg-tool
+# Get the latest release using the 0.x git tag
+wget https://github.com/phil-harmoniq/netpkg-tool/releases/download/0.x/netpkg-tool
 chmod a+x netpkg-tool
 
 # Place it somewhere on your $PATH (Optional)
@@ -46,7 +46,7 @@ netpkg-tool aspnet-src . -n aspnet-pkg
 
 ## ASP.NET
 
-ASP.NET is picky about where its content root directory is located. By default, it searches for `wwwroot` in `Directory.GetCurrentDirectory()`. Using netpkg-tool on an unmodified ASP.NET project will result in your web app being unable to locate any of its assets. A simple workaround would be to check for the existence of an environment variable set by netpkg-tool, like `$HERE`, and setting the content directory accordingly. This will allow the project's content to be found regardless of whether it's packaged up or being run with `dotnet run`. Example:
+ASP.NET is picky about where its content root directory is located. By default, it searches for `wwwroot` in `Directory.GetCurrentDirectory()`. Using netpkg-tool on an unmodified ASP.NET project will result in your web app being unable to locate any of its assets. A simple workaround would be to check for the existence of an environment variable set by netpkg-tool, like `$NET_PKG`, and setting the content directory to the Assembly location if it exists. This will allow the project's content to be found regardless of whether it's packaged up or being run with `dotnet run`. Example:
 
 ```C#
 public class Program

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,7 @@
 #! /usr/bin/env bash
 
 export HERE=$(dirname "$(readlink -f "${0}")")
+cd "$HERE"
 
 if [[ -z "$1" ]] || [[ ! -d "$1" ]]; then
     echo "You must specify a build destination folder"

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,7 @@
 #! /usr/bin/env bash
 
+set -e
+
 export HERE=$(dirname "$(readlink -f "${0}")")
 cd "$HERE"
 

--- a/file-transfer.sh
+++ b/file-transfer.sh
@@ -36,9 +36,9 @@ touch /tmp/"$APP_NAME".temp/AppRun
     fi
 
     if [[ -z $MAKE_SCD ]]; then
-        echo 'dotnet "$HERE/usr/share/'"$APP_NAME"'/'"$DLL_NAME.dll"'" "$@"'
+        echo 'exec -a "'"$APP_NAME"'" dotnet "$HERE/usr/share/'"$APP_NAME"'/'"$DLL_NAME.dll"'" "$@"'
     else
-        echo '$HERE/usr/share/'"$APP_NAME"'/'"$DLL_NAME"' "$@"'
+        echo 'exec -a '"$HERE"'/usr/share/'"$APP_NAME"'/'"$DLL_NAME"' "$@"'
     fi
 } >> /tmp/"$APP_NAME".temp/AppRun
 
@@ -57,7 +57,8 @@ touch /tmp/"$APP_NAME".temp/"$APP_NAME".desktop
 touch /tmp/"$APP_NAME".temp/"$APP_NAME"-icon.png
 
 # Set executable
-chmod +x /tmp/"$APP_NAME".temp/AppRun
+chmod a+x /tmp/"$APP_NAME".temp/AppRun
+chmod u+x /tmp/"$APP_NAME".temp/usr/share/"$APP_NAME"/"$DLL_NAME".dll
 
 # Check for netpkg.lib and import libraries
 if [[ -d $PROJECT/netpkg.lib ]]; then

--- a/file-transfer.sh
+++ b/file-transfer.sh
@@ -38,7 +38,7 @@ touch /tmp/"$APP_NAME".temp/AppRun
     if [[ -z $MAKE_SCD ]]; then
         echo 'exec -a "'"$APP_NAME"'" dotnet "$HERE/usr/share/'"$APP_NAME"'/'"$DLL_NAME.dll"'" "$@"'
     else
-        echo 'exec -a '"$HERE"'/usr/share/'"$APP_NAME"'/'"$DLL_NAME"' "$@"'
+        echo 'exec -a "'"$APP_NAME"'" "$HERE/usr/share/'"$APP_NAME"'/'"$DLL_NAME"'" "$@"'
     fi
 } >> /tmp/"$APP_NAME".temp/AppRun
 

--- a/netpkg-tool.csproj
+++ b/netpkg-tool.csproj
@@ -7,7 +7,7 @@
     <Authors>Phil Hawkins</Authors>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <VersionPrefix>0.3.1</VersionPrefix>
+    <VersionPrefix>0.3.2</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
     <Description>Quick and easy console colors for C#/Unix</Description>
     <Copyright>MIT</Copyright>


### PR DESCRIPTION
- Added error logger. Log file will be located at ~/.local/share/netpkg-tool/error.log
 - Added --clear-log to delete error log
 - Process name correctly reflects AppName
 - Remove unnecessary ConsolidatePath()