### PR TITLE
0.3.7

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -104,9 +104,7 @@ class Program
 
     static void FindCsproj(string project)
     {
-        
-        bash.Command($"find {project} -maxdepth 1 -name '*.csproj'", redirect: true);
-        var location = bash.Lines;
+        var location = bash.Command($"find {project} -maxdepth 1 -name '*.csproj'", redirect: true).Lines;
 
         if (location.Length < 1)
             ExitWithError($"No .csproj found in {GetRelativePath(project)}\n", 10);

--- a/netpkg-tool.csproj
+++ b/netpkg-tool.csproj
@@ -7,7 +7,7 @@
     <Authors>Phil Hawkins</Authors>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <VersionPrefix>0.3.6</VersionPrefix>
+    <VersionPrefix>0.3.7</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
     <Description>Bundle .NET Core applications into convenient Linux binaries using appimagetool</Description>
     <Copyright>MIT</Copyright>


### PR DESCRIPTION
- SCD builds were broken with the final .NET Core SDK release
  - Declaring a single `<RuntimeIdentifier>` attribute will force the .NET Core CLI to publish using SCD
  - netpkg-tool will now properly pick up on the `<RuntimeIdentifier>` and switch to SCD if it exists
  - If there is a `<RuntimeIdentifier>` without using the --scd flag, netpkg-tool will give a small warning