### PR TITLE
0.3.9

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -201,7 +201,7 @@ class Program
     static void RunAppImageTool()
     {
         var appimgtool = $"{Here}/appimagetool/AppRun";
-        var cmd = $"{appimgtool} -n /tmp/{AppName}.temp {Destination}/{AppName}";
+        var cmd = $"ARCH=x86_64 {appimgtool} -n /tmp/{AppName}.temp {Destination}/{AppName}";
 
         if (Verbose)
         {

--- a/Program.cs
+++ b/Program.cs
@@ -201,7 +201,7 @@ class Program
     static void RunAppImageTool()
     {
         var appimgtool = $"{Here}/appimagetool/AppRun";
-        var cmd = $"ARCH=x86_64 {appimgtool} -n /tmp/{AppName}.temp {Destination}/{AppName}";
+        var cmd = $"{appimgtool} -n /tmp/{AppName}.temp {Destination}/{AppName}";
 
         if (Verbose)
         {

--- a/Program.cs
+++ b/Program.cs
@@ -8,11 +8,11 @@ using ConsoleColors;
 
 class Program
 {
-    static Assembly tool = Assembly.GetExecutingAssembly();
-    static string ToolName = tool.GetName().Name;
-    static string ToolVersion = FileVersionInfo.GetVersionInfo(tool.Location).ProductVersion;
+    static Assembly Dll = Assembly.GetExecutingAssembly();
+    static string ToolName = Dll.GetName().Name;
+    static string ToolVersion = FileVersionInfo.GetVersionInfo(Dll.Location).ProductVersion;
     static string Home = Environment.GetEnvironmentVariable("HOME");
-    static string configDir = $"{Home}/.netpkg-tool";
+    static string ConfigDir = $"{Home}/.netpkg-tool";
     static int Width = 64;
     static Shell.NET.Bash Bash = new Shell.NET.Bash();
     static string Csproj;
@@ -179,7 +179,7 @@ class Program
             Console.Write("Compiling .NET Core project...");
             Bash.Command(cmd, redirect: true);
         }
-        
+
         CheckCommandOutput(errorCode: 21);
     }
 
@@ -264,8 +264,8 @@ class Program
 
     static void ClearLogs()
     {
-        Console.Write($"Clear log at {GetRelativePath(configDir)}/error.log");
-        Bash.Rm($"{configDir}/error.log", "-f");
+        Console.Write($"Clear log at {GetRelativePath(ConfigDir)}/error.log");
+        Bash.Rm($"{ConfigDir}/error.log", "-f");
         CheckCommandOutput(errorCode: 5);
         SayBye();
         Environment.Exit(0);
@@ -288,10 +288,10 @@ class Program
 
     static void WriteToErrorLog(string message, int code)
     {
-        if (!Directory.Exists(configDir))
-            Directory.CreateDirectory(configDir);
+        if (!Directory.Exists(ConfigDir))
+            Directory.CreateDirectory(ConfigDir);
         
-        using (var tw = new StreamWriter($"{configDir}/error.log", true))
+        using (var tw = new StreamWriter($"{ConfigDir}/error.log", true))
         {
             var now = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss");
             var dir = Directory.GetCurrentDirectory();

--- a/README.md
+++ b/README.md
@@ -92,13 +92,13 @@ Using *netpkg-tool* will restore and compile your project based on settings in y
 1. Restore project dependencies
 1. Compile .NET Core app
 1. Create AppDir and transfer files
-1. Run appimagetool on created AppDir
+1. Run *appimagetool* on created AppDir
 1. Delete temporary files
 
 ## Dependencies
 
 - [.NET Core 2.0 SDK](https://www.microsoft.com/net/core/preview): Per-distro [RID](https://docs.microsoft.com/en-us/dotnet/core/rid-catalog) tags were replaced with the universal `linux-x64` [RID](https://github.com/dotnet/cli/issues/2727), simplifying the Linux build process. Earlier versions *should* work with *netpkg-tool* but only using [Framework Dependent Deployment](https://docs.microsoft.com/en-us/dotnet/core/deploying/#framework-dependent-deployments-fdd).
-- [appimagetool](https://github.com/AppImage/AppImageKit): (Included) Bundles linux applications into AppImages.
+- [appimagetool](https://github.com/AppImage/AppImageKit): (Included) Bundles Linux applications into AppImages, currently utilizes version 9 of *appimagetool*.
 - [Shell.NET](https://github.com/phil-harmoniq/Shell.NET): (Included) .NET Standard library for interacting with Bash.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -90,16 +90,20 @@ public class Program
 Using *netpkg-tool* will restore and compile your project based on settings in your `*.csproj` file. By default, *netpkg-tool* will use [Framework Dependent Deployment](https://docs.microsoft.com/en-us/dotnet/core/deploying/#framework-dependent-deployments-fdd) to compile your project. To use [Self-Contained Deployment](https://docs.microsoft.com/en-us/dotnet/core/deploying/#self-contained-deployments-scd), use the `--scd` flag. The full process for *netpkg-tool*:
 
 1. Restore project dependencies
-2. Compile .NET Core app
-3. Create AppDir and transfer files
-4. Run appimagetool on created AppDir
-5. Delete temporary files
+1. Compile .NET Core app
+1. Create AppDir and transfer files
+1. Run appimagetool on created AppDir
+1. Delete temporary files
 
 ## Dependencies
 
 - [.NET Core 2.0 SDK](https://www.microsoft.com/net/core/preview): Per-distro [RID](https://docs.microsoft.com/en-us/dotnet/core/rid-catalog) tags were replaced with the universal `linux-x64` [RID](https://github.com/dotnet/cli/issues/2727), simplifying the Linux build process. Earlier versions *should* work with *netpkg-tool* but only using [Framework Dependent Deployment](https://docs.microsoft.com/en-us/dotnet/core/deploying/#framework-dependent-deployments-fdd).
 - [appimagetool](https://github.com/AppImage/AppImageKit): (Included) Bundles linux applications into AppImages.
 - [Shell.NET](https://github.com/phil-harmoniq/Shell.NET): (Included) .NET Standard library for interacting with Bash.
+
+## Contributing
+
+If you have a feature request or issue, feel free to submit an [issue](https://github.com/phil-harmoniq/netpkg-tool/issues). A pull request would be even better! Pull requests should target the `develop` branch.
 
 ## Mono
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 Pre-packaged versions of *netpkg-tool* are available from the [releases tab](https://github.com/phil-harmoniq/netpkg-tool/releases):
 
 ```bash
-# Github releases are tagged with their version (ex: 0.3.8)
-wget https://github.com/phil-harmoniq/netpkg-tool/releases/download/0.3.8/netpkg-tool
+# Github releases are tagged with their version (ex: 0.3.9)
+wget https://github.com/phil-harmoniq/netpkg-tool/releases/download/0.3.9/netpkg-tool
 chmod a+x ./netpkg-tool
 
 # Place netpkg-tool somewhere on your $PATH (Optional)

--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,6 @@
 set -e
 
 export HERE=$(dirname "$(readlink -f "${0}")")
-cd "$HERE"
 
 if [[ -z "$1" ]] || [[ ! -d "$1" ]]; then
     echo "You must specify a build destination folder"
@@ -17,5 +16,5 @@ else
         mv "$HERE/squashfs-root" "$HERE/appimagetool"
         rm "$HERE/appimagetool.AppImage"
     fi
-    dotnet run --project "$HERE" "$HERE" "$1"
+    dotnet run --project "$HERE" "$HERE" "$1" 
 fi

--- a/build.sh
+++ b/build.sh
@@ -4,16 +4,19 @@ set -e
 
 export HERE=$(dirname "$(readlink -f "${0}")")
 
-if [[ -z "$1" ]] || [[ ! -d "$1" ]]; then
+if [[ "$1" == "--clean" ]]; then
+    rm -r "$HERE/appimagetool"
+    echo "Removed $HERE/appimagetool"
+elif [[ -z "$1" ]] || [[ ! -d "$1" ]]; then
     echo "You must specify a build destination folder"
 else
-    if [[ ! -d "$HERE/appimagetool" ]]; then
+    if [[ ! -f "$HERE/appimagetool/AppRun" ]]; then
         rm -rf "$HERE/squashfs-root" "$HERE/appimagetool.AppImage"
-        wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage \
+        wget https://github.com/AppImage/AppImageKit/releases/download/9/appimagetool-x86_64.AppImage \
             -O "$HERE/appimagetool.AppImage"
         chmod a+x "$HERE/appimagetool.AppImage"
         "$HERE/appimagetool.AppImage" --appimage-extract
-        mv "$HERE/squashfs-root" "$HERE/appimagetool"
+        mv "$PWD/squashfs-root" "$HERE/appimagetool"
         rm "$HERE/appimagetool.AppImage"
     fi
     dotnet run --project "$HERE" "$HERE" "$1" 

--- a/file-transfer.sh
+++ b/file-transfer.sh
@@ -58,7 +58,6 @@ touch /tmp/"$APP_NAME".temp/"$APP_NAME"-icon.png
 
 # Set executable
 chmod a+x /tmp/"$APP_NAME".temp/AppRun
-chmod u+x /tmp/"$APP_NAME".temp/usr/share/"$APP_NAME"/"$DLL_NAME".dll
 
 # Check for netpkg.lib and import libraries
 if [[ -d $PROJECT/netpkg.lib ]]; then

--- a/file-transfer.sh
+++ b/file-transfer.sh
@@ -1,5 +1,8 @@
 #! /usr/bin/env bash
 
+# Hard exit if any part of the script fails
+set -e
+
 # Store variables from C#
 PROJECT="$1"
 DLL_NAME="$2"
@@ -7,9 +10,6 @@ APP_NAME="$3"
 CORE_VERS="$4"
 NET_PKG="$5"
 MAKE_SCD="$6"
-
-# Hard exit if any part of the script fails
-set -e
 
 # Remove old temp folder & make new one
 rm -rf /tmp/"$APP_NAME".temp

--- a/netpkg-tool.csproj
+++ b/netpkg-tool.csproj
@@ -7,7 +7,7 @@
     <Authors>Phil Hawkins</Authors>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <VersionPrefix>0.3.8</VersionPrefix>
+    <VersionPrefix>0.3.9</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
     <Description>Bundle .NET Core applications into convenient Linux binaries using appimagetool</Description>
     <Copyright>MIT</Copyright>
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Shell.Net" Version="0.1.7-alpha"/>
+    <PackageReference Include="Shell.Net" Version="0.2.0"/>
     <PackageReference Include="ConsoleColors" Version="0.1.9-alpha"/>
   </ItemGroup>
 


### PR DESCRIPTION
- Depend on a stable version of appimagetool (v9)
- Update Shell.NET
- Fix redundancies